### PR TITLE
Fix ESLint configuration and CI/CD errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "browser": true,
     "es2021": true,
-    "webextensions": true
+    "webextensions": true,
+    "node": true
   },
   "extends": "eslint:recommended",
   "parserOptions": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: 依存関係のインストール
       run: |
         npm init -y
-        npm install --save-dev eslint
+        npm install --save-dev eslint@8.57.0
 
     - name: 静的解析の実行
       run: |
@@ -47,7 +47,7 @@ jobs:
     - name: 依存関係のインストール
       run: |
         npm init -y
-        npm install --save-dev @babel/core @babel/preset-env babel-loader webpack webpack-cli zip-webpack-plugin clean-webpack-plugin copy-webpack-plugin eslint
+        npm install --save-dev @babel/core @babel/preset-env babel-loader webpack webpack-cli zip-webpack-plugin clean-webpack-plugin copy-webpack-plugin eslint@8.57.0
 
     - name: webpackの設定ファイル作成
       run: |

--- a/content.js
+++ b/content.js
@@ -11,6 +11,20 @@ let confirmedTweetIds = new Set();
 // 自分のIDとフォロワーのIDを保存するセット
 let myAndFollowersIds = new Set();
 
+// ディストーションの設定（バキッとした音にするため）
+function makeDistortionCurve(amount) {
+  const k = typeof amount === 'number' ? amount : 50;
+  const nSamples = 44100;
+  const curve = new Float32Array(nSamples);
+  const deg = Math.PI / 180;
+  
+  for (let i = 0; i < nSamples; ++i) {
+    const x = (i * 2) / nSamples - 1;
+    curve[i] = (3 + k) * x * 20 * deg / (Math.PI + k * Math.abs(x));
+  }
+  return curve;
+}
+
 
 // 設定を読み込む
 function loadSettings() {
@@ -404,18 +418,6 @@ function playBlockSound() {
     const distortion = audioContext.createWaveShaper();
     
     // ディストーションの設定（バキッとした音にするため）
-    function makeDistortionCurve(amount) {
-      const k = typeof amount === 'number' ? amount : 50;
-      const n_samples = 44100;
-      const curve = new Float32Array(n_samples);
-      const deg = Math.PI / 180;
-      
-      for (let i = 0; i < n_samples; ++i) {
-        const x = (i * 2) / n_samples - 1;
-        curve[i] = (3 + k) * x * 20 * deg / (Math.PI + k * Math.abs(x));
-      }
-      return curve;
-    }
     
     distortion.curve = makeDistortionCurve(400);
     distortion.oversample = '4x';


### PR DESCRIPTION
This PR fixes the CI/CD build errors mentioned in issue #22.

Changes made:
1. Downgraded ESLint from v9.x to v8.57.0 in both lint and build jobs in the GitHub workflow
2. Added "node": true to .eslintrc.json env section to fix node-related errors
3. Fixed no-inner-declarations error by moving the makeDistortionCurve function to the top level of content.js

These changes should resolve the ESLint errors that were causing the CI/CD pipeline to fail.